### PR TITLE
ADD: no-block-arrow-callback's definition

### DIFF
--- a/docs/rules/no-block-arrow-callbacks.md
+++ b/docs/rules/no-block-arrow-callbacks.md
@@ -1,0 +1,46 @@
+# Prevents the bad practice of complex callback chains
+
+## Rule Details
+
+This rule was inspired by the functional practices of functional
+composition. It is unfortunately quite common in javascript to compose
+complex chains of callbacks using just function expressions.
+
+This rule pushes the developer to keep there higher level abstractions
+clean by only allowing defined functions, or blockless arrow functions
+to be used as callbacks.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/* eslint no-arrow-block-callbacks: "error" */
+anArray
+  .map(x => {
+    const xPlus10 =       //
+      x + 10              // Complex inline callbacks muddy the abstraction
+                          //
+    return xPlus10
+  })
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/* eslint no-arrow-block-callbacks: "error" */
+anArray
+  .map(x => x + 10)
+  .map(x => x - 9)
+
+anArray
+  .map(adds10)
+  .map(minus9)
+
+anArray                     //
+  .map(function add10(x) {  // Allowed for es5 tanda
+    return x + 10           //
+  })
+```
+
+## When Not To Use It
+This rule is quite restricting... may not want to buy in.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   rules: {
     'enforce-i18n-keys': require('./lib/rules/enforce-i18n-keys'),
+    'no-block-arrow-callbacks': require('./lib/rules/no-block-arrow-callbacks'),
     'no-disallowed-props': require('./lib/rules/no-disallowed-props'),
   }
 }

--- a/lib/rules/no-block-arrow-callbacks.js
+++ b/lib/rules/no-block-arrow-callbacks.js
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Prevents usage of fat arrows used with bodies in callbacks
+ * @author Leon Pearce
+ */
+
+"use strict";
+
+// -------------------------------- PLUGIN --------------------------------- //
+
+module.exports = {
+
+    meta: {
+      docs: {
+        description: 'disallow arrow function expression callbacks with a block statment as a body',
+        category: 'Best Practices',
+      },
+      fixable: null,
+      schema: [],
+    },
+
+    create(ctx) {
+      return {
+        'ArrowFunctionExpression:exit': noArrowBlockCallbacks(ctx),
+      }
+    }
+
+  }
+
+
+
+// -------------------------------- RULES ---------------------------------- //
+
+/**
+ * checks is function expression is an arrow function with a body positioned
+ * as a callback.
+ *
+ * @param {*} node
+ */
+function noArrowBlockCallbacks(ctx) {
+  return (node) => {
+    if (hasBody(node) && isCallback(node)) {
+      ctx.report({
+        node,
+        message: MESSAGE,
+      })
+    }
+  }
+}
+
+
+
+// ------------------------------- HELPERS --------------------------------- //
+
+/**
+ * Evaluates if node is a callback
+ */
+function isCallback(node) {
+  return node.parent.type === CALL_EXPRESSION ||
+         node.parent.type === NEW_EXPRESSION
+}
+
+/**
+ * Evaluates if a node has `BlockStatement` as a body type
+ *
+ * @param {Estree.Node} node
+ * @returns {boolean} whether body type is a `BlockStatement`
+ */
+function hasBody(node) {
+  return node.body.type === BLOCK_STATEMENT
+}
+
+
+
+// ------------------------------ CONSTANTS -------------------------------- //
+
+const MESSAGE =
+`
+Do not use an arrow function as a callback with a block for a body!
+use either an an arrow function with an expression body or define
+your function, for code readability.
+
+e.g.
+  // good examples
+  anArray.map(x => x + 10)
+  anArray.map(addTen)
+
+  // bad examples
+  anArray.map(x => {
+    if (x > 10) {
+      return x - 10
+    }
+
+    return x + 10
+  })
+`
+
+const BLOCK_STATEMENT =
+  "BlockStatement"
+
+const CALL_EXPRESSION =
+  "CallExpression"
+
+const NEW_EXPRESSION =
+  "NewExpression"

--- a/tests/lib/rules/no-block-arrow-callbacks.js
+++ b/tests/lib/rules/no-block-arrow-callbacks.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Prevents usage of fat arrows used with bodies in callbacks
+ * @author Leon Pearce
+ */
+
+"use strict";
+
+const rule = require("../../../lib/rules/no-block-arrow-callbacks");
+const RuleTester = require("eslint").RuleTester;
+
+
+
+// ------------------------------- FIXTURES -------------------------------- //
+
+const good1 =
+`
+anArray
+  .map(x => x + 10)
+  .map(x => x - 9)
+`
+
+const good2 =
+`
+anArray
+  .map(adds10)
+  .map(minus9)
+`
+
+const good3 =
+`
+anArray
+  .map(function add10(x) {
+    return x + 10
+  })
+`
+
+const bad1 =
+`
+anArray
+  .map(x => {
+    return x + 10
+  })
+`
+
+const MESSAGE =
+`
+Do not use an arrow function as a callback with a block for a body!
+use either an an arrow function with an expression body or define
+your function, for code readability.
+
+e.g.
+  // good examples
+  anArray.map(x => x + 10)
+  anArray.map(addTen)
+
+  // bad examples
+  anArray.map(x => {
+    if (x > 10) {
+      return x - 10
+    }
+
+    return x + 10
+  })
+`
+
+
+
+// ------------------------------- RUN SUITE ------------------------------- //
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+};
+
+new RuleTester({ parserOptions }).run("no-block-arrow-callbacks", rule, {
+  valid: [
+    { code: good1 },
+    { code: good2 },
+    { code: good3 },
+  ],
+  invalid: [
+    { code: bad1, errors: [{ message: MESSAGE }] },
+  ]
+});


### PR DESCRIPTION
This is a very strict rule, and definitely comes with buy in!

The idea is to improve practices of functional composition around callbacks. call backs are a higher level abstraction and using complex function expressions could be considered code smell? (tbh there are some pretty reasonable use cases though).

this rule catches usages of function expressions as callback if they are an `arrow function expression` and have a `block body`. it does not have an opinion on regular function expressions, and simple (expression body) arrow function expressions.