### PR TITLE
Don't crash on attributes without values

### DIFF
--- a/lib/rules/enforce-i18n-keys.js
+++ b/lib/rules/enforce-i18n-keys.js
@@ -125,6 +125,11 @@ module.exports = {
             if (!attribute.name) {
               return;
             }
+            if (!attribute.value) {
+              // if there's no attribute value, it's implicitly `true`
+              // and can be ignored by this plugin (which only cares about string values)
+              return;
+            }
             const attributeName = attribute.name.name;
             const isAllowedItem = allowedItems.includes(attributeName);
             const isNative = isNativeComponent(componentName);


### PR DESCRIPTION
An example is:

```jsx
      <Row
        title={t(key)}
        lightText
      />
```

The plugin was crashing in the `verifyAttribute` function with attribute `lightText`.